### PR TITLE
refactor(logger): replace slog with bullets logging library

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/pjbgf/sha1cd v0.3.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 // indirect
+	github.com/sgaunet/bullets v0.1.0 // indirect
 	github.com/skeema/knownhosts v1.3.1 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -93,6 +93,8 @@ github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
+github.com/sgaunet/bullets v0.1.0 h1:SbuYp7265LjlOLFKTIY1CBzP+4PzbmEXFSZ7sipOQR0=
+github.com/sgaunet/bullets v0.1.0/go.mod h1:mDQHozgrlZ3yjWFigjxr2f0DpGA9VCu1hV0mdOcwkd0=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/skeema/knownhosts v1.3.1 h1:X2osQ+RAjK76shCbvhHHHVl3ZlgDm8apHEHFqRjnBY8=
 github.com/skeema/knownhosts v1.3.1/go.mod h1:r7KTdC8l4uxWRyK2TpQZ/1o5HaSzh06ePQNxPwTcfiY=

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -1,12 +1,13 @@
-// Package logger provides logging utilities for gitlab-backup2s3.
+// Package logger provides logging utilities for auto-mr.
 package logger
 
 import (
-	"log/slog"
 	"os"
+
+	"github.com/sgaunet/bullets"
 )
 
-// Logger is the interface for logging in gitlab-backup2s3.
+// Logger is the interface for logging in auto-mr.
 type Logger interface {
 	Debug(msg string, args ...any)
 	Info(msg string, args ...any)
@@ -18,29 +19,28 @@ type Logger interface {
 // logLevel is the level of logging
 // Possible values of logLevel are: "debug", "info", "warn", "error"
 // Default value is "info".
-func NewLogger(logLevel string) *slog.Logger {
-	var level slog.Level
+func NewLogger(logLevel string) *bullets.Logger {
+	var level bullets.Level
 	switch logLevel {
 	case "debug":
-		level = slog.LevelDebug
+		level = bullets.DebugLevel
 	case "info":
-		level = slog.LevelInfo
+		level = bullets.InfoLevel
 	case "warn":
-		level = slog.LevelWarn
+		level = bullets.WarnLevel
 	case "error":
-		level = slog.LevelError
+		level = bullets.ErrorLevel
 	default:
-		level = slog.LevelInfo
+		level = bullets.InfoLevel
 	}
-	logHandler := slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
-		Level:     level,
-		AddSource: false,
-	})
-	logger := slog.New(logHandler)
+	logger := bullets.New(os.Stdout)
+	logger.SetLevel(level)
 	return logger
 }
 
 // NoLogger creates a logger that does not log anything.
-func NoLogger() *slog.Logger {
-	return slog.New(slog.DiscardHandler)
+func NoLogger() *bullets.Logger {
+	logger := bullets.New(os.Stdout)
+	logger.SetLevel(bullets.FatalLevel)
+	return logger
 }

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -1,7 +1,6 @@
 package logger_test
 
 import (
-	"log/slog"
 	"testing"
 
 	"github.com/sgaunet/auto-mr/internal/logger"
@@ -24,13 +23,12 @@ func TestNoLogger(t *testing.T) {
 func TestNewLogger(t *testing.T) {
 	tests := []struct {
 		logLevel string
-		expected slog.Level
 	}{
-		{"debug", slog.LevelDebug},
-		{"info", slog.LevelInfo},
-		{"warn", slog.LevelWarn},
-		{"error", slog.LevelError},
-		{"", slog.LevelInfo}, // Default case
+		{"debug"},
+		{"info"},
+		{"warn"},
+		{"error"},
+		{""}, // Default case
 	}
 
 	for _, tt := range tests {

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -3,15 +3,15 @@ package ui
 
 import (
 	"fmt"
-	"log/slog"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/sgaunet/auto-mr/internal/logger"
+	"github.com/sgaunet/bullets"
 )
 
 // LabelSelector provides interactive label selection functionality.
 type LabelSelector struct {
-	log *slog.Logger
+	log *bullets.Logger
 }
 
 // Label represents a label that can be selected.
@@ -25,7 +25,7 @@ func NewLabelSelector() *LabelSelector {
 }
 
 // SetLogger sets the logger for the label selector.
-func (ls *LabelSelector) SetLogger(logger *slog.Logger) {
+func (ls *LabelSelector) SetLogger(logger *bullets.Logger) {
 	ls.log = logger
 }
 
@@ -41,7 +41,7 @@ func (ls *LabelSelector) SelectLabels(labels []Label, maxSelection int) ([]strin
 		options[i] = label.GetName()
 	}
 
-	ls.log.Debug("Prompting user to select labels", "available", len(labels), "max", maxSelection)
+	ls.log.Debug(fmt.Sprintf("Prompting user to select labels - available: %d, max: %d", len(labels), maxSelection))
 	var selected []string
 	prompt := &survey.MultiSelect{
 		Message: "Choose labels:",
@@ -62,7 +62,7 @@ func (ls *LabelSelector) SelectLabels(labels []Label, maxSelection int) ([]strin
 		selected = selected[:maxSelection]
 	}
 
-	ls.log.Debug("Labels selected", "count", len(selected))
+	ls.log.Debug(fmt.Sprintf("Labels selected, count: %d", len(selected)))
 	return selected, nil
 }
 


### PR DESCRIPTION
refactor(logger): replace slog with bullets logging library

Replace standard library log/slog with github.com/sgaunet/bullets
for structured logging. This change affects all packages that use
logging (git, github, gitlab, ui, logger, main).

- Update logger.NewLogger to use bullets.Logger with custom levels
- Convert all structured logging calls to formatted strings
- Update logger interface references across all packages
- Maintain same log levels (debug, info, warn, error)
