### PR TITLE
feat(github): delete remote branch after successful PR merge

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/AlecAivazis/survey/v2 v2.3.7
 	github.com/go-git/go-git/v5 v5.16.2
 	github.com/google/go-github/v69 v69.2.0
+	github.com/sgaunet/bullets v0.1.0
 	github.com/spf13/cobra v1.10.1
 	github.com/stretchr/testify v1.11.1
 	gitlab.com/gitlab-org/api/client-go v0.148.1
@@ -38,7 +39,6 @@ require (
 	github.com/pjbgf/sha1cd v0.3.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 // indirect
-	github.com/sgaunet/bullets v0.1.0 // indirect
 	github.com/skeema/knownhosts v1.3.1 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/main.go
+++ b/main.go
@@ -403,6 +403,14 @@ func waitAndMergeGitHubPR(client *ghclient.Client, pr *github.PullRequest) error
 	}
 
 	log.Info("Pull request merged successfully")
+
+	// Delete remote branch after successful merge (matching shell script behavior)
+	log.Infof("Deleting remote branch: %s", *pr.Head.Ref)
+	if err := client.DeleteBranch(*pr.Head.Ref); err != nil {
+		log.Warnf("Failed to delete remote branch: %v", err)
+		// Don't fail the entire operation if branch deletion fails
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
feat(github): delete remote branch after successful PR merge

- Add explicit remote branch deletion after GitHub PR merge
- Use existing DeleteBranch method to remove remote branch
- Match shell script behavior (gh pr merge --delete-branch)
- Graceful failure handling with warning if deletion fails
- Update go.mod to move bullets from indirect to direct dependency
