### PR TITLE
feat: add --squash flag to control commit squashing behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,13 +63,26 @@ export GITHUB_TOKEN="your-github-token"
 auto-mr
 ```
 
+### Options
+
+- `--squash`: Squash commits when merging (default: false, preserves commit history)
+- `--log-level`: Set log level (debug, info, warn, error) (default: "info")
+- `--version`: Print version and exit
+
+Example with squash:
+```bash
+auto-mr --squash
+```
+
+### Workflow
+
 The tool will:
 1. Detect if you're using GitLab or GitHub
 2. Push your current branch
 3. Let you select labels interactively
 4. Create a merge/pull request with proper assignee and reviewer
 5. Wait for CI/CD pipeline completion
-6. Auto-approve (GitLab only) and merge the request
+6. Auto-approve (GitLab only) and merge the request (squash if --squash flag is used)
 7. Switch back to main branch and clean up
 
 ## Replaced Dependencies

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -279,6 +279,7 @@ func (c *Client) WaitForWorkflows(timeout time.Duration) (string, error) {
 }
 
 // MergePullRequest merges a pull request using the specified merge method.
+// mergeMethod can be "merge", "squash", or "rebase".
 func (c *Client) MergePullRequest(prNumber int, mergeMethod string) error {
 	c.log.Debug(fmt.Sprintf("Merging pull request #%d using method: %s", prNumber, mergeMethod))
 	options := &github.PullRequestOptions{
@@ -357,6 +358,15 @@ func (c *Client) hasWorkflowRuns() bool {
 // ctx returns the context for API calls.
 func (c *Client) ctx() context.Context {
 	return context.Background()
+}
+
+// GetMergeMethod returns the appropriate merge method string based on squash flag.
+// Returns "squash" if squash is true, otherwise "merge".
+func GetMergeMethod(squash bool) string {
+	if squash {
+		return "squash"
+	}
+	return "merge"
 }
 
 // formatDuration formats a duration into a human-readable string.

--- a/pkg/gitlab/gitlab.go
+++ b/pkg/gitlab/gitlab.go
@@ -144,7 +144,7 @@ func (c *Client) ListLabels() ([]*Label, error) {
 // CreateMergeRequest creates a new merge request with assignees, reviewers, and labels.
 func (c *Client) CreateMergeRequest(
 	sourceBranch, targetBranch, title, description, assignee, reviewer string,
-	labels []string,
+	labels []string, squash bool,
 ) (*gitlab.MergeRequest, error) {
 	c.log.Debug(fmt.Sprintf("Creating merge request from %s to %s", sourceBranch, targetBranch))
 
@@ -175,7 +175,7 @@ func (c *Client) CreateMergeRequest(
 		AssigneeID:         &assigneeID,
 		ReviewerIDs:        &reviewerIDs,
 		Labels:             labelOptions,
-		Squash:             gitlab.Ptr(true),
+		Squash:             gitlab.Ptr(squash),
 		RemoveSourceBranch: gitlab.Ptr(true),
 	}
 
@@ -285,10 +285,10 @@ func (c *Client) ApproveMergeRequest(mrIID int) error {
 }
 
 // MergeMergeRequest merges a merge request.
-func (c *Client) MergeMergeRequest(mrIID int) error {
+func (c *Client) MergeMergeRequest(mrIID int, squash bool) error {
 	c.log.Debug(fmt.Sprintf("Merging merge request, IID: %d", mrIID))
 	mergeOptions := &gitlab.AcceptMergeRequestOptions{
-		Squash:             gitlab.Ptr(true),
+		Squash:             gitlab.Ptr(squash),
 		ShouldRemoveSourceBranch: gitlab.Ptr(true),
 	}
 


### PR DESCRIPTION
feat: add --squash flag to control commit squashing behavior

Add optional --squash CLI flag to allow users to choose whether commits
are squashed when merging. Default behavior preserves commit history.

- Add --squash boolean flag (default: false)
- Update GitLab client to accept squash parameter
- Update GitHub client with GetMergeMethod helper
- Pass squash flag through merge workflow
- Update README with flag documentation

Closes #17
