### PR TITLE
feat(release): add homebrew tap publishing support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,3 +58,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Your GoReleaser Pro key, if you are using the 'goreleaser-pro' distribution
           # GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -42,3 +42,21 @@ changelog:
     exclude:
       - '^docs:'
       - '^test:'
+
+brews:
+  - homepage: 'https://github.com/sgaunet/auto-mr'
+    description: ''
+    directory: Formula
+    commit_author:
+      name: sgaunet
+      email: 1552102+sgaunet@users.noreply.github.com
+    repository:
+      owner: sgaunet
+      name: homebrew-tools
+      # Token with 'repo' scope is required for pushing to a different repository
+      token: '{{ .Env.HOMEBREW_TAP_TOKEN }}'
+    url_template: 'https://github.com/sgaunet/auto-mr/releases/download/{{ .Tag }}/{{ .ArtifactName }}'
+    install: |
+      bin.install "{{ .ArtifactName }}" => "auto-mr"
+    test: |
+      system "#{bin}/auto-mr", "--help"


### PR DESCRIPTION
feat(release): add homebrew tap publishing support

Configure GoReleaser to publish releases to sgaunet/homebrew-tools tap repository with automated formula generation and GitHub token authentication
