### PR TITLE
fix(github): use selected commit message for merge instead of default

### DIFF
--- a/main.go
+++ b/main.go
@@ -388,7 +388,7 @@ func handleGitHub(cfg *config.Config, currentBranch, mainBranch, title, body str
 		return err
 	}
 
-	if err := waitAndMergeGitHubPR(client, pr, squash); err != nil {
+	if err := waitAndMergeGitHubPR(client, pr, title, body, squash); err != nil {
 		return err
 	}
 
@@ -470,7 +470,12 @@ func createGitHubPR(
 	return pr, nil
 }
 
-func waitAndMergeGitHubPR(client *ghclient.Client, pr *github.PullRequest, squash bool) error {
+func waitAndMergeGitHubPR(
+	client *ghclient.Client,
+	pr *github.PullRequest,
+	commitTitle, commitBody string,
+	squash bool,
+) error {
 	time.Sleep(pipelineStartupDelay)
 
 	conclusion, err := client.WaitForWorkflows(defaultPipelineTimeout)
@@ -486,7 +491,7 @@ func waitAndMergeGitHubPR(client *ghclient.Client, pr *github.PullRequest, squas
 	log.IncreasePadding()
 
 	mergeMethod := ghclient.GetMergeMethod(squash)
-	if err := client.MergePullRequest(*pr.Number, mergeMethod); err != nil {
+	if err := client.MergePullRequest(*pr.Number, mergeMethod, commitTitle, commitBody); err != nil {
 		log.DecreasePadding()
 		return fmt.Errorf("failed to merge pull request: %w", err)
 	}

--- a/pkg/github/api.go
+++ b/pkg/github/api.go
@@ -151,13 +151,16 @@ func (c *Client) GetPullRequestByBranch(head, base string) (*github.PullRequest,
 
 // MergePullRequest merges a pull request using the specified merge method.
 // mergeMethod can be "merge", "squash", or "rebase".
-func (c *Client) MergePullRequest(prNumber int, mergeMethod string) error {
+// commitTitle and commitBody are used as the merge commit message.
+func (c *Client) MergePullRequest(prNumber int, mergeMethod, commitTitle, commitBody string) error {
 	c.log.Debug(fmt.Sprintf("Merging pull request #%d using method: %s", prNumber, mergeMethod))
 	options := &github.PullRequestOptions{
 		MergeMethod: mergeMethod, // "squash", "merge", or "rebase"
+		CommitTitle: commitTitle,  // Use selected commit title as merge commit title
 	}
 
-	_, _, err := c.client.PullRequests.Merge(c.ctx(), c.owner, c.repo, prNumber, "", options)
+	// Pass commit body as the merge commit message
+	_, _, err := c.client.PullRequests.Merge(c.ctx(), c.owner, c.repo, prNumber, commitBody, options)
 	if err != nil {
 		return fmt.Errorf("failed to merge pull request: %w", err)
 	}

--- a/pkg/github/client_test.go
+++ b/pkg/github/client_test.go
@@ -298,7 +298,7 @@ func TestMergePullRequest(t *testing.T) {
 		t.Run("merge with "+strategy.method, func(t *testing.T) {
 			mockAPI := mocks.NewGitHubAPIClient()
 
-			err := mockAPI.MergePullRequest(123, strategy.method)
+			err := mockAPI.MergePullRequest(123, strategy.method, "Test commit", "Test body")
 			if err != nil {
 				t.Fatalf("Unexpected error: %v", err)
 			}
@@ -319,7 +319,7 @@ func TestMergePullRequest(t *testing.T) {
 		mockAPI := mocks.NewGitHubAPIClient()
 		mockAPI.MergePullRequestError = ghpkg.ErrInvalidURLFormat
 
-		err := mockAPI.MergePullRequest(123, "merge")
+		err := mockAPI.MergePullRequest(123, "merge", "Test commit", "Test body")
 		if err == nil {
 			t.Error("Expected merge error")
 		}

--- a/pkg/github/edgecases_test.go
+++ b/pkg/github/edgecases_test.go
@@ -195,7 +195,7 @@ func TestEdgeCaseBoundaryValues(t *testing.T) {
 		mockAPI := mocks.NewGitHubAPIClient()
 
 		// PR number 0 might be treated as invalid
-		err := mockAPI.MergePullRequest(0, "squash")
+		err := mockAPI.MergePullRequest(0, "squash", "Test commit", "Test body")
 		// Behavior depends on implementation - just verify it's handled
 		_ = err
 	})
@@ -204,7 +204,7 @@ func TestEdgeCaseBoundaryValues(t *testing.T) {
 		mockAPI := mocks.NewGitHubAPIClient()
 
 		// Negative PR number should be invalid
-		err := mockAPI.MergePullRequest(-1, "squash")
+		err := mockAPI.MergePullRequest(-1, "squash", "Test commit", "Test body")
 		// Behavior depends on implementation - just verify it's handled
 		_ = err
 	})

--- a/pkg/github/errors_test.go
+++ b/pkg/github/errors_test.go
@@ -151,7 +151,7 @@ func TestErrorAPIFailures(t *testing.T) {
 		mockAPI := mocks.NewGitHubAPIClient()
 		mockAPI.MergePullRequestError = errors.New("405 Method Not Allowed")
 
-		err := mockAPI.MergePullRequest(123, "squash")
+		err := mockAPI.MergePullRequest(123, "squash", "Test commit", "Test body")
 		if err == nil {
 			t.Error("Expected merge error")
 		}
@@ -285,7 +285,7 @@ func TestErrorAuthenticationFailures(t *testing.T) {
 		mockAPI := mocks.NewGitHubAPIClient()
 		mockAPI.MergePullRequestError = errors.New("403 Resource not accessible by integration")
 
-		err := mockAPI.MergePullRequest(123, "squash")
+		err := mockAPI.MergePullRequest(123, "squash", "Test commit", "Test body")
 		if err == nil {
 			t.Error("Expected insufficient permissions error")
 		}

--- a/pkg/github/interfaces.go
+++ b/pkg/github/interfaces.go
@@ -35,7 +35,8 @@ type APIClient interface {
 
 	// MergePullRequest merges a pull request using the specified merge method.
 	// mergeMethod can be "merge", "squash", or "rebase".
-	MergePullRequest(prNumber int, mergeMethod string) error
+	// commitTitle and commitBody are used as the merge commit message.
+	MergePullRequest(prNumber int, mergeMethod, commitTitle, commitBody string) error
 
 	// GetPullRequestsByHead returns all open pull requests for the given head branch.
 	GetPullRequestsByHead(head string) ([]*github.PullRequest, error)

--- a/pkg/github/workflows_test.go
+++ b/pkg/github/workflows_test.go
@@ -39,7 +39,7 @@ func TestWorkflowPRCreationToMerge(t *testing.T) {
 		}
 
 		// Step 3: Merge PR
-		err = mockAPI.MergePullRequest(*pr.Number, "squash")
+		err = mockAPI.MergePullRequest(*pr.Number, "squash", "Test commit", "Test body")
 		if err != nil {
 			t.Fatalf("Failed to merge PR: %v", err)
 		}
@@ -126,7 +126,7 @@ func TestWorkflowPRUpdateAndRetry(t *testing.T) {
 		}
 
 		// Now merge
-		err = mockAPI.MergePullRequest(*pr.Number, "squash")
+		err = mockAPI.MergePullRequest(*pr.Number, "squash", "Test commit", "Test body")
 		if err != nil {
 			t.Fatalf("Failed to merge PR: %v", err)
 		}
@@ -199,7 +199,7 @@ func TestWorkflowBranchCleanup(t *testing.T) {
 		mockAPI.WaitForWorkflowsConclusion = "success"
 		_, _ = mockAPI.WaitForWorkflows(5 * time.Minute)
 
-		err := mockAPI.MergePullRequest(*pr.Number, "squash")
+		err := mockAPI.MergePullRequest(*pr.Number, "squash", "Test commit", "Test body")
 		if err != nil {
 			t.Fatalf("Failed to merge PR: %v", err)
 		}
@@ -245,7 +245,7 @@ func TestWorkflowFindExistingPR(t *testing.T) {
 		}
 
 		// Merge existing PR
-		err = mockAPI.MergePullRequest(*pr.Number, "merge")
+		err = mockAPI.MergePullRequest(*pr.Number, "merge", "Test commit", "Test body")
 		if err != nil {
 			t.Fatalf("Failed to merge existing PR: %v", err)
 		}
@@ -312,7 +312,7 @@ func TestWorkflowMergeStrategies(t *testing.T) {
 			_, _ = mockAPI.WaitForWorkflows(5 * time.Minute)
 
 			// Merge with specific strategy
-			err := mockAPI.MergePullRequest(*pr.Number, strategy.method)
+			err := mockAPI.MergePullRequest(*pr.Number, strategy.method, "Test commit", "Test body")
 			if err != nil {
 				t.Fatalf("Failed to merge with %s: %v", strategy.method, err)
 			}
@@ -366,7 +366,7 @@ func TestWorkflowWithLabels(t *testing.T) {
 		// Complete workflow
 		mockAPI.WaitForWorkflowsConclusion = "success"
 		_, _ = mockAPI.WaitForWorkflows(5 * time.Minute)
-		_ = mockAPI.MergePullRequest(*pr.Number, "squash")
+		_ = mockAPI.MergePullRequest(*pr.Number, "squash", "Test commit", "Test body")
 	})
 }
 
@@ -424,6 +424,6 @@ func TestWorkflowStateValidation(t *testing.T) {
 		// Proceed with workflow
 		mockAPI.WaitForWorkflowsConclusion = "success"
 		_, _ = mockAPI.WaitForWorkflows(5 * time.Minute)
-		_ = mockAPI.MergePullRequest(*pr.Number, "squash")
+		_ = mockAPI.MergePullRequest(*pr.Number, "squash", "Test commit", "Test body")
 	})
 }

--- a/testing/mocks/github_mocks.go
+++ b/testing/mocks/github_mocks.go
@@ -94,10 +94,12 @@ func (m *GitHubAPIClient) WaitForWorkflows(timeout time.Duration) (string, error
 }
 
 // MergePullRequest implements github.APIClient.
-func (m *GitHubAPIClient) MergePullRequest(prNumber int, mergeMethod string) error {
+func (m *GitHubAPIClient) MergePullRequest(prNumber int, mergeMethod, commitTitle, commitBody string) error {
 	m.trackCall("MergePullRequest", map[string]any{
 		"prNumber":    prNumber,
 		"mergeMethod": mergeMethod,
+		"commitTitle": commitTitle,
+		"commitBody":  commitBody,
 	})
 	return m.MergePullRequestError
 }


### PR DESCRIPTION
- Add commitTitle and commitBody parameters to MergePullRequest method
- Pass selected commit message through waitAndMergeGitHubPR call chain
- Set GitHub API CommitTitle and commitMessage with selected values
- Update interface, mocks, and all test calls to match new signature

This ensures GitHub merge commits use the selected/single commit message
from the feature branch instead of the default "Merge pull request #N" format.