### PR TITLE
fix(merge): use selected commit title for merge commit message

### DIFF
--- a/main.go
+++ b/main.go
@@ -259,7 +259,7 @@ func handleGitLab(cfg *config.Config, currentBranch, mainBranch, title, body str
 		return err
 	}
 
-	if err := waitAndMergeGitLabMR(client, mr, squash); err != nil {
+	if err := waitAndMergeGitLabMR(client, mr, squash, title); err != nil {
 		return err
 	}
 
@@ -342,7 +342,7 @@ func createGitLabMR(
 	return mr, nil
 }
 
-func waitAndMergeGitLabMR(client *gitlab.Client, mr *gogitlab.MergeRequest, squash bool) error {
+func waitAndMergeGitLabMR(client *gitlab.Client, mr *gogitlab.MergeRequest, squash bool, commitTitle string) error {
 	time.Sleep(pipelineStartupDelay)
 
 	status, err := client.WaitForPipeline(defaultPipelineTimeout)
@@ -362,7 +362,7 @@ func waitAndMergeGitLabMR(client *gitlab.Client, mr *gogitlab.MergeRequest, squa
 		log.Warnf("Failed to approve merge request: %v", err)
 	}
 
-	if err := client.MergeMergeRequest(mr.IID, squash); err != nil {
+	if err := client.MergeMergeRequest(mr.IID, squash, commitTitle); err != nil {
 		log.DecreasePadding()
 		return fmt.Errorf("failed to merge MR: %w", err)
 	}
@@ -388,7 +388,7 @@ func handleGitHub(cfg *config.Config, currentBranch, mainBranch, title, body str
 		return err
 	}
 
-	if err := waitAndMergeGitHubPR(client, pr, title, body, squash); err != nil {
+	if err := waitAndMergeGitHubPR(client, pr, title, squash); err != nil {
 		return err
 	}
 
@@ -473,7 +473,7 @@ func createGitHubPR(
 func waitAndMergeGitHubPR(
 	client *ghclient.Client,
 	pr *github.PullRequest,
-	commitTitle, commitBody string,
+	commitTitle string,
 	squash bool,
 ) error {
 	time.Sleep(pipelineStartupDelay)
@@ -491,7 +491,7 @@ func waitAndMergeGitHubPR(
 	log.IncreasePadding()
 
 	mergeMethod := ghclient.GetMergeMethod(squash)
-	if err := client.MergePullRequest(*pr.Number, mergeMethod, commitTitle, commitBody); err != nil {
+	if err := client.MergePullRequest(*pr.Number, mergeMethod, commitTitle); err != nil {
 		log.DecreasePadding()
 		return fmt.Errorf("failed to merge pull request: %w", err)
 	}

--- a/pkg/github/api.go
+++ b/pkg/github/api.go
@@ -151,16 +151,16 @@ func (c *Client) GetPullRequestByBranch(head, base string) (*github.PullRequest,
 
 // MergePullRequest merges a pull request using the specified merge method.
 // mergeMethod can be "merge", "squash", or "rebase".
-// commitTitle and commitBody are used as the merge commit message.
-func (c *Client) MergePullRequest(prNumber int, mergeMethod, commitTitle, commitBody string) error {
+// commitTitle is used as the merge commit message.
+func (c *Client) MergePullRequest(prNumber int, mergeMethod, commitTitle string) error {
 	c.log.Debug(fmt.Sprintf("Merging pull request #%d using method: %s", prNumber, mergeMethod))
 	options := &github.PullRequestOptions{
 		MergeMethod: mergeMethod, // "squash", "merge", or "rebase"
 		CommitTitle: commitTitle,  // Use selected commit title as merge commit title
 	}
 
-	// Pass commit body as the merge commit message
-	_, _, err := c.client.PullRequests.Merge(c.ctx(), c.owner, c.repo, prNumber, commitBody, options)
+	// Pass commit title as the merge commit message
+	_, _, err := c.client.PullRequests.Merge(c.ctx(), c.owner, c.repo, prNumber, commitTitle, options)
 	if err != nil {
 		return fmt.Errorf("failed to merge pull request: %w", err)
 	}

--- a/pkg/github/client_test.go
+++ b/pkg/github/client_test.go
@@ -298,7 +298,7 @@ func TestMergePullRequest(t *testing.T) {
 		t.Run("merge with "+strategy.method, func(t *testing.T) {
 			mockAPI := mocks.NewGitHubAPIClient()
 
-			err := mockAPI.MergePullRequest(123, strategy.method, "Test commit", "Test body")
+			err := mockAPI.MergePullRequest(123, strategy.method, "Test commit")
 			if err != nil {
 				t.Fatalf("Unexpected error: %v", err)
 			}
@@ -319,7 +319,7 @@ func TestMergePullRequest(t *testing.T) {
 		mockAPI := mocks.NewGitHubAPIClient()
 		mockAPI.MergePullRequestError = ghpkg.ErrInvalidURLFormat
 
-		err := mockAPI.MergePullRequest(123, "merge", "Test commit", "Test body")
+		err := mockAPI.MergePullRequest(123, "merge", "Test commit")
 		if err == nil {
 			t.Error("Expected merge error")
 		}

--- a/pkg/github/edgecases_test.go
+++ b/pkg/github/edgecases_test.go
@@ -195,7 +195,7 @@ func TestEdgeCaseBoundaryValues(t *testing.T) {
 		mockAPI := mocks.NewGitHubAPIClient()
 
 		// PR number 0 might be treated as invalid
-		err := mockAPI.MergePullRequest(0, "squash", "Test commit", "Test body")
+		err := mockAPI.MergePullRequest(0, "squash", "Test commit")
 		// Behavior depends on implementation - just verify it's handled
 		_ = err
 	})
@@ -204,7 +204,7 @@ func TestEdgeCaseBoundaryValues(t *testing.T) {
 		mockAPI := mocks.NewGitHubAPIClient()
 
 		// Negative PR number should be invalid
-		err := mockAPI.MergePullRequest(-1, "squash", "Test commit", "Test body")
+		err := mockAPI.MergePullRequest(-1, "squash", "Test commit")
 		// Behavior depends on implementation - just verify it's handled
 		_ = err
 	})

--- a/pkg/github/errors_test.go
+++ b/pkg/github/errors_test.go
@@ -151,7 +151,7 @@ func TestErrorAPIFailures(t *testing.T) {
 		mockAPI := mocks.NewGitHubAPIClient()
 		mockAPI.MergePullRequestError = errors.New("405 Method Not Allowed")
 
-		err := mockAPI.MergePullRequest(123, "squash", "Test commit", "Test body")
+		err := mockAPI.MergePullRequest(123, "squash", "Test commit")
 		if err == nil {
 			t.Error("Expected merge error")
 		}
@@ -285,7 +285,7 @@ func TestErrorAuthenticationFailures(t *testing.T) {
 		mockAPI := mocks.NewGitHubAPIClient()
 		mockAPI.MergePullRequestError = errors.New("403 Resource not accessible by integration")
 
-		err := mockAPI.MergePullRequest(123, "squash", "Test commit", "Test body")
+		err := mockAPI.MergePullRequest(123, "squash", "Test commit")
 		if err == nil {
 			t.Error("Expected insufficient permissions error")
 		}

--- a/pkg/github/interfaces.go
+++ b/pkg/github/interfaces.go
@@ -35,8 +35,8 @@ type APIClient interface {
 
 	// MergePullRequest merges a pull request using the specified merge method.
 	// mergeMethod can be "merge", "squash", or "rebase".
-	// commitTitle and commitBody are used as the merge commit message.
-	MergePullRequest(prNumber int, mergeMethod, commitTitle, commitBody string) error
+	// commitTitle is used as the merge commit message.
+	MergePullRequest(prNumber int, mergeMethod, commitTitle string) error
 
 	// GetPullRequestsByHead returns all open pull requests for the given head branch.
 	GetPullRequestsByHead(head string) ([]*github.PullRequest, error)

--- a/pkg/github/workflows_test.go
+++ b/pkg/github/workflows_test.go
@@ -39,7 +39,7 @@ func TestWorkflowPRCreationToMerge(t *testing.T) {
 		}
 
 		// Step 3: Merge PR
-		err = mockAPI.MergePullRequest(*pr.Number, "squash", "Test commit", "Test body")
+		err = mockAPI.MergePullRequest(*pr.Number, "squash", "Test commit")
 		if err != nil {
 			t.Fatalf("Failed to merge PR: %v", err)
 		}
@@ -126,7 +126,7 @@ func TestWorkflowPRUpdateAndRetry(t *testing.T) {
 		}
 
 		// Now merge
-		err = mockAPI.MergePullRequest(*pr.Number, "squash", "Test commit", "Test body")
+		err = mockAPI.MergePullRequest(*pr.Number, "squash", "Test commit")
 		if err != nil {
 			t.Fatalf("Failed to merge PR: %v", err)
 		}
@@ -199,7 +199,7 @@ func TestWorkflowBranchCleanup(t *testing.T) {
 		mockAPI.WaitForWorkflowsConclusion = "success"
 		_, _ = mockAPI.WaitForWorkflows(5 * time.Minute)
 
-		err := mockAPI.MergePullRequest(*pr.Number, "squash", "Test commit", "Test body")
+		err := mockAPI.MergePullRequest(*pr.Number, "squash", "Test commit")
 		if err != nil {
 			t.Fatalf("Failed to merge PR: %v", err)
 		}
@@ -245,7 +245,7 @@ func TestWorkflowFindExistingPR(t *testing.T) {
 		}
 
 		// Merge existing PR
-		err = mockAPI.MergePullRequest(*pr.Number, "merge", "Test commit", "Test body")
+		err = mockAPI.MergePullRequest(*pr.Number, "merge", "Test commit")
 		if err != nil {
 			t.Fatalf("Failed to merge existing PR: %v", err)
 		}
@@ -312,7 +312,7 @@ func TestWorkflowMergeStrategies(t *testing.T) {
 			_, _ = mockAPI.WaitForWorkflows(5 * time.Minute)
 
 			// Merge with specific strategy
-			err := mockAPI.MergePullRequest(*pr.Number, strategy.method, "Test commit", "Test body")
+			err := mockAPI.MergePullRequest(*pr.Number, strategy.method, "Test commit")
 			if err != nil {
 				t.Fatalf("Failed to merge with %s: %v", strategy.method, err)
 			}
@@ -366,7 +366,7 @@ func TestWorkflowWithLabels(t *testing.T) {
 		// Complete workflow
 		mockAPI.WaitForWorkflowsConclusion = "success"
 		_, _ = mockAPI.WaitForWorkflows(5 * time.Minute)
-		_ = mockAPI.MergePullRequest(*pr.Number, "squash", "Test commit", "Test body")
+		_ = mockAPI.MergePullRequest(*pr.Number, "squash", "Test commit")
 	})
 }
 
@@ -424,6 +424,6 @@ func TestWorkflowStateValidation(t *testing.T) {
 		// Proceed with workflow
 		mockAPI.WaitForWorkflowsConclusion = "success"
 		_, _ = mockAPI.WaitForWorkflows(5 * time.Minute)
-		_ = mockAPI.MergePullRequest(*pr.Number, "squash", "Test commit", "Test body")
+		_ = mockAPI.MergePullRequest(*pr.Number, "squash", "Test commit")
 	})
 }

--- a/pkg/gitlab/api.go
+++ b/pkg/gitlab/api.go
@@ -258,12 +258,19 @@ func (c *Client) ApproveMergeRequest(mrIID int) error {
 }
 
 // MergeMergeRequest merges a merge request.
-func (c *Client) MergeMergeRequest(mrIID int, squash bool) error {
+func (c *Client) MergeMergeRequest(mrIID int, squash bool, commitTitle string) error {
 	c.log.Debug(fmt.Sprintf("Merging merge request, IID: %d", mrIID))
 
 	mergeOptions := &gitlab.AcceptMergeRequestOptions{
 		Squash:                   gitlab.Ptr(squash),
 		ShouldRemoveSourceBranch: gitlab.Ptr(true),
+	}
+
+	// Set commit message based on squash mode
+	if squash {
+		mergeOptions.SquashCommitMessage = gitlab.Ptr(commitTitle)
+	} else {
+		mergeOptions.MergeCommitMessage = gitlab.Ptr(commitTitle)
 	}
 
 	_, _, err := c.client.MergeRequests.AcceptMergeRequest(c.projectID, mrIID, mergeOptions)

--- a/pkg/gitlab/client_test.go
+++ b/pkg/gitlab/client_test.go
@@ -299,7 +299,7 @@ func TestMergeMergeRequest(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			mockAPI := mocks.NewGitLabAPIClient()
 
-			err := mockAPI.MergeMergeRequest(123, tt.squash)
+			err := mockAPI.MergeMergeRequest(123, tt.squash, "Test commit")
 			if err != nil {
 				t.Fatalf("Failed to merge MR: %v", err)
 			}
@@ -309,6 +309,9 @@ func TestMergeMergeRequest(t *testing.T) {
 			if lastCall.Args["squash"] != tt.squash {
 				t.Errorf("Expected squash %v, got %v", tt.squash, lastCall.Args["squash"])
 			}
+			if lastCall.Args["commitTitle"] != "Test commit" {
+				t.Errorf("Expected commitTitle 'Test commit', got %v", lastCall.Args["commitTitle"])
+			}
 		})
 	}
 
@@ -316,7 +319,7 @@ func TestMergeMergeRequest(t *testing.T) {
 		mockAPI := mocks.NewGitLabAPIClient()
 		mockAPI.MergeMergeRequestError = gitlab.ErrMRNotFound
 
-		err := mockAPI.MergeMergeRequest(123, false)
+		err := mockAPI.MergeMergeRequest(123, false, "Test commit")
 		if err == nil {
 			t.Error("Expected error but got nil")
 		}

--- a/pkg/gitlab/errors_test.go
+++ b/pkg/gitlab/errors_test.go
@@ -98,7 +98,7 @@ func TestErrorAPIFailures(t *testing.T) {
 				m.MergeMergeRequestError = gitlab.ErrMRNotFound
 			},
 			testFunc: func(m *mocks.GitLabAPIClient) error {
-				return m.MergeMergeRequest(123, false)
+				return m.MergeMergeRequest(123, false, "Test commit")
 			},
 		},
 		{

--- a/pkg/gitlab/interfaces.go
+++ b/pkg/gitlab/interfaces.go
@@ -39,7 +39,7 @@ type APIClient interface {
 
 	// MergeMergeRequest merges a merge request with optional squash.
 	// Returns an error if the merge fails.
-	MergeMergeRequest(mrIID int, squash bool) error
+	MergeMergeRequest(mrIID int, squash bool, commitTitle string) error
 
 	// GetMergeRequestsByBranch returns all open merge requests for the given source branch.
 	GetMergeRequestsByBranch(sourceBranch string) ([]*gitlab.BasicMergeRequest, error)

--- a/pkg/gitlab/workflows_test.go
+++ b/pkg/gitlab/workflows_test.go
@@ -37,7 +37,7 @@ func TestWorkflowMRCreationToMerge(t *testing.T) {
 		}
 
 		// Step 4: Merge MR
-		err = mockAPI.MergeMergeRequest(123, false)
+		err = mockAPI.MergeMergeRequest(123, false, "Test commit")
 		if err != nil {
 			t.Fatalf("Failed to merge MR: %v", err)
 		}
@@ -114,7 +114,7 @@ func TestWorkflowMRUpdateAndRetry(t *testing.T) {
 
 		// Now approve and merge
 		_ = mockAPI.ApproveMergeRequest(123)
-		_ = mockAPI.MergeMergeRequest(123, false)
+		_ = mockAPI.MergeMergeRequest(123, false, "Test commit")
 
 		// Verify retry pattern
 		if mockAPI.GetCallCount("WaitForPipeline") != 2 {
@@ -142,7 +142,7 @@ func TestWorkflowFindExistingMR(t *testing.T) {
 
 		// Approve and merge existing MR
 		_ = mockAPI.ApproveMergeRequest(123)
-		_ = mockAPI.MergeMergeRequest(123, false)
+		_ = mockAPI.MergeMergeRequest(123, false, "Test commit")
 
 		// Verify workflow
 		if mockAPI.GetCallCount("GetMergeRequestByBranch") != 1 {
@@ -181,12 +181,15 @@ func TestWorkflowSquashMerge(t *testing.T) {
 
 			// Approve and merge with specific squash setting
 			_ = mockAPI.ApproveMergeRequest(123)
-			_ = mockAPI.MergeMergeRequest(123, tt.squash)
+			_ = mockAPI.MergeMergeRequest(123, tt.squash, "Test commit")
 
 			// Verify squash setting
 			lastCall := mockAPI.GetLastCall("MergeMergeRequest")
 			if lastCall.Args["squash"] != tt.squash {
 				t.Errorf("Expected squash %v, got %v", tt.squash, lastCall.Args["squash"])
+			}
+			if lastCall.Args["commitTitle"] != "Test commit" {
+				t.Errorf("Expected commitTitle 'Test commit', got %v", lastCall.Args["commitTitle"])
 			}
 		})
 	}
@@ -225,7 +228,7 @@ func TestWorkflowWithLabels(t *testing.T) {
 		mockAPI.WaitForPipelineStatus = "success"
 		_, _ = mockAPI.WaitForPipeline(5 * time.Minute)
 		_ = mockAPI.ApproveMergeRequest(123)
-		_ = mockAPI.MergeMergeRequest(123, false)
+		_ = mockAPI.MergeMergeRequest(123, false, "Test commit")
 	})
 }
 
@@ -252,7 +255,7 @@ func TestWorkflowApprovalScenarios(t *testing.T) {
 		}
 
 		// Merge after approval
-		err = mockAPI.MergeMergeRequest(123, false)
+		err = mockAPI.MergeMergeRequest(123, false, "Test commit")
 		if err != nil {
 			t.Fatalf("Failed to merge MR: %v", err)
 		}

--- a/testing/mocks/github_mocks.go
+++ b/testing/mocks/github_mocks.go
@@ -94,12 +94,11 @@ func (m *GitHubAPIClient) WaitForWorkflows(timeout time.Duration) (string, error
 }
 
 // MergePullRequest implements github.APIClient.
-func (m *GitHubAPIClient) MergePullRequest(prNumber int, mergeMethod, commitTitle, commitBody string) error {
+func (m *GitHubAPIClient) MergePullRequest(prNumber int, mergeMethod, commitTitle string) error {
 	m.trackCall("MergePullRequest", map[string]any{
 		"prNumber":    prNumber,
 		"mergeMethod": mergeMethod,
 		"commitTitle": commitTitle,
-		"commitBody":  commitBody,
 	})
 	return m.MergePullRequestError
 }

--- a/testing/mocks/gitlab_mocks.go
+++ b/testing/mocks/gitlab_mocks.go
@@ -94,10 +94,11 @@ func (m *GitLabAPIClient) ApproveMergeRequest(mrIID int) error {
 }
 
 // MergeMergeRequest implements gitlab.APIClient.
-func (m *GitLabAPIClient) MergeMergeRequest(mrIID int, squash bool) error {
+func (m *GitLabAPIClient) MergeMergeRequest(mrIID int, squash bool, commitTitle string) error {
 	m.trackCall("MergeMergeRequest", map[string]any{
-		"mrIID":  mrIID,
-		"squash": squash,
+		"mrIID":       mrIID,
+		"squash":      squash,
+		"commitTitle": commitTitle,
 	})
 	return m.MergeMergeRequestError
 }


### PR DESCRIPTION
- GitLab: Add commitTitle parameter to MergeMergeRequest()
- GitLab: Set MergeCommitMessage/SquashCommitMessage based on squash mode
- GitHub: Remove commitBody parameter, use only commitTitle
- Update main workflow functions to pass commit title correctly
- Update all test files and mocks to match new signatures

Fixes issue where GitLab MR title and GitHub PR used wrong commit message
for the merge commit. Both platforms now correctly use the user-selected
commit title from the interactive commit selection.