### PR TITLE
fix(git): add native git fallback for SSH auth in GetMainBranch and PushBranch

### DIFF
--- a/testing/fixtures/gitlab_fixtures.go
+++ b/testing/fixtures/gitlab_fixtures.go
@@ -1,6 +1,7 @@
 package fixtures
 
 import (
+	"fmt"
 	"time"
 
 	glpkg "github.com/sgaunet/auto-mr/pkg/gitlab"
@@ -192,7 +193,7 @@ func BasicMergeRequest(iid int64, sourceBranch, targetBranch string) *gitlab.Bas
 		SourceBranch: sourceBranch,
 		TargetBranch: targetBranch,
 		State:        "opened",
-		WebURL:       "https://gitlab.com/owner/project/-/merge_requests/" + string(rune(iid)),
+		WebURL:       fmt.Sprintf("https://gitlab.com/owner/project/-/merge_requests/%d", iid),
 	}
 }
 

--- a/testing/mocks/github_mocks.go
+++ b/testing/mocks/github_mocks.go
@@ -267,7 +267,7 @@ func (m *MockDisplayRenderer) String() string {
 	defer m.mu.Unlock()
 	var result strings.Builder
 	for i, msg := range m.messages {
-		result.WriteString(fmt.Sprintf("[%d] %s: %s\n", i, msg.Level, msg.Message))
+		fmt.Fprintf(&result, "[%d] %s: %s\n", i, msg.Level, msg.Message)
 	}
 	return result.String()
 }


### PR DESCRIPTION
- Refactor GetMainBranch into 3-tier fallback: go-git, native git, local branch
- Use "git ls-remote --symref" as fallback when go-git SSH fails
- Add native "git push" fallback when go-git push fails with SSH errors
- Fix ls-remote output parsing (branch name is in second field, not first)
- Follows existing pattern of native git for network operations

Refs #72