### PR TITLE
fix(auth): trim whitespace from platform tokens

### DIFF
--- a/pkg/forgejo/forgejo.go
+++ b/pkg/forgejo/forgejo.go
@@ -25,6 +25,7 @@ package forgejo
 import (
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"code.gitea.io/sdk/gitea"
@@ -40,7 +41,7 @@ import (
 //
 // Returns [ErrTokenRequired] if FORGEJO_TOKEN is not set.
 func NewClient(baseURL string) (*Client, error) {
-	token := os.Getenv("FORGEJO_TOKEN")
+	token := strings.TrimSpace(os.Getenv("FORGEJO_TOKEN"))
 	if token == "" {
 		return nil, errTokenRequired
 	}

--- a/pkg/forgejo/forgejo_test.go
+++ b/pkg/forgejo/forgejo_test.go
@@ -37,6 +37,34 @@ func TestNewClientMissingToken(t *testing.T) {
 	}
 }
 
+// TestNewClientWhitespaceTokenTrimmed verifies that a whitespace-only FORGEJO_TOKEN
+// is trimmed to empty and reported as missing, rather than producing an invalid
+// Authorization header. This guards against the gitea SDK rejecting a token with a
+// trailing newline ("net/http: invalid header field value for Authorization").
+func TestNewClientWhitespaceTokenTrimmed(t *testing.T) {
+	original := os.Getenv("FORGEJO_TOKEN")
+	if err := os.Setenv("FORGEJO_TOKEN", "   \n\t "); err != nil {
+		t.Fatalf("failed to set FORGEJO_TOKEN: %v", err)
+	}
+
+	defer func() {
+		if original == "" {
+			if err := os.Unsetenv("FORGEJO_TOKEN"); err != nil {
+				t.Errorf("failed to unset FORGEJO_TOKEN: %v", err)
+			}
+			return
+		}
+		if err := os.Setenv("FORGEJO_TOKEN", original); err != nil {
+			t.Errorf("failed to restore FORGEJO_TOKEN: %v", err)
+		}
+	}()
+
+	_, err := forgejo.NewClient("https://forgejo.example.com")
+	if !errors.Is(err, forgejo.ErrTokenRequired) {
+		t.Errorf("expected ErrTokenRequired for whitespace-only token, got: %v", err)
+	}
+}
+
 // TestNewClientWithToken verifies that NewClient does not return ErrTokenRequired
 // when FORGEJO_TOKEN is set. The SDK performs a live version check on the base URL,
 // so this test skips when the example host is unreachable.

--- a/pkg/github/client_test.go
+++ b/pkg/github/client_test.go
@@ -1,6 +1,8 @@
 package github_test
 
 import (
+	"errors"
+	"os"
 	"testing"
 	"time"
 
@@ -17,6 +19,33 @@ func TestClientConstructor(t *testing.T) {
 		// Skip for now as it would affect other tests
 		t.Skip("Requires environment manipulation")
 	})
+}
+
+// TestNewClientWhitespaceTokenTrimmed verifies that a whitespace-only GITHUB_TOKEN
+// is trimmed to empty and reported as missing, rather than producing an invalid
+// Authorization header.
+func TestNewClientWhitespaceTokenTrimmed(t *testing.T) {
+	original := os.Getenv("GITHUB_TOKEN")
+	if err := os.Setenv("GITHUB_TOKEN", "   \n\t "); err != nil {
+		t.Fatalf("failed to set GITHUB_TOKEN: %v", err)
+	}
+
+	defer func() {
+		if original == "" {
+			if err := os.Unsetenv("GITHUB_TOKEN"); err != nil {
+				t.Errorf("failed to unset GITHUB_TOKEN: %v", err)
+			}
+			return
+		}
+		if err := os.Setenv("GITHUB_TOKEN", original); err != nil {
+			t.Errorf("failed to restore GITHUB_TOKEN: %v", err)
+		}
+	}()
+
+	_, err := ghpkg.NewClient()
+	if !errors.Is(err, ghpkg.ErrTokenRequired) {
+		t.Errorf("expected ErrTokenRequired for whitespace-only token, got: %v", err)
+	}
 }
 
 // TestSetRepositoryFromURL tests repository URL parsing and validation.

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -27,6 +27,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/google/go-github/v69/github"
@@ -40,7 +41,7 @@ import (
 //
 // Returns [ErrTokenRequired] if GITHUB_TOKEN is not set.
 func NewClient() (*Client, error) {
-	token := os.Getenv("GITHUB_TOKEN")
+	token := strings.TrimSpace(os.Getenv("GITHUB_TOKEN"))
 	if token == "" {
 		return nil, errTokenRequired
 	}

--- a/pkg/gitlab/api.go
+++ b/pkg/gitlab/api.go
@@ -20,7 +20,7 @@ import (
 // Returns [ErrTokenRequired] if GITLAB_TOKEN is not set.
 // Returns a wrapped error if the underlying GitLab client creation fails.
 func NewClient() (*Client, error) {
-	token := os.Getenv("GITLAB_TOKEN")
+	token := strings.TrimSpace(os.Getenv("GITLAB_TOKEN"))
 	if token == "" {
 		return nil, errTokenRequired
 	}

--- a/pkg/gitlab/client_test.go
+++ b/pkg/gitlab/client_test.go
@@ -1,6 +1,8 @@
 package gitlab_test
 
 import (
+	"errors"
+	"os"
 	"testing"
 	"time"
 
@@ -15,6 +17,33 @@ func TestClientConstructor(t *testing.T) {
 	t.Run("NewClient requires GITLAB_TOKEN", func(t *testing.T) {
 		t.Skip("Requires environment manipulation")
 	})
+}
+
+// TestNewClientWhitespaceTokenTrimmed verifies that a whitespace-only GITLAB_TOKEN
+// is trimmed to empty and reported as missing, rather than producing an invalid
+// Authorization header.
+func TestNewClientWhitespaceTokenTrimmed(t *testing.T) {
+	original := os.Getenv("GITLAB_TOKEN")
+	if err := os.Setenv("GITLAB_TOKEN", "   \n\t "); err != nil {
+		t.Fatalf("failed to set GITLAB_TOKEN: %v", err)
+	}
+
+	defer func() {
+		if original == "" {
+			if err := os.Unsetenv("GITLAB_TOKEN"); err != nil {
+				t.Errorf("failed to unset GITLAB_TOKEN: %v", err)
+			}
+			return
+		}
+		if err := os.Setenv("GITLAB_TOKEN", original); err != nil {
+			t.Errorf("failed to restore GITLAB_TOKEN: %v", err)
+		}
+	}()
+
+	_, err := gitlab.NewClient()
+	if !errors.Is(err, gitlab.ErrTokenRequired) {
+		t.Errorf("expected ErrTokenRequired for whitespace-only token, got: %v", err)
+	}
 }
 
 // TestSetProjectFromURL tests the SetProjectFromURL method with various URL formats.


### PR DESCRIPTION
- TrimSpace FORGEJO_TOKEN, GITHUB_TOKEN, GITLAB_TOKEN at read time to
  prevent invalid Authorization headers (a trailing newline broke the
  gitea SDK's eager /api/v1/version check at client construction)
- whitespace-only token now correctly returns ErrTokenRequired
- add TestNewClientWhitespaceTokenTrimmed to forgejo/github/gitlab

Closes #98